### PR TITLE
[MAINT] increased quick / nimble version for JOYCE spm support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,12 +2,30 @@
   "object": {
     "pins": [
       {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "f809deb30dc5c9d9b78c872e553261a61177721a",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
+          "version": "2.0.0"
+        }
+      },
+      {
         "package": "Nimble",
         "repositoryURL": "https://github.com/Quick/Nimble",
         "state": {
           "branch": null,
-          "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",
-          "version": "8.0.2"
+          "revision": "7a54aaf19a8ef16f67787c260fda81ead7ba4d67",
+          "version": "9.0.1"
         }
       },
       {
@@ -15,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Quick",
         "state": {
           "branch": null,
-          "revision": "94df9b449508344667e5afc7e80f8bcbff1e4c37",
-          "version": "2.1.0"
+          "revision": "8cce6acd38f965f5baa3167b939f86500314022b",
+          "version": "3.1.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
       targets: ["Shuffle"])
   ],
   dependencies: [
-    .package(url: "https://github.com/Quick/Quick", from: "2.1.0"),
-    .package(url: "https://github.com/Quick/Nimble", from: "8.0.2")
+    .package(url: "https://github.com/Quick/Quick", from: "3.1.2"),
+    .package(url: "https://github.com/Quick/Nimble", from: "9.0.1")
   ],
   targets: [
     .target(


### PR DESCRIPTION
We are currently migrating all our CocoaPods dependencies to Swift Package Manger. In order to reuse the sub-dependencies `Quick` and `Nimble` for our test targets we have to use the current release versions.